### PR TITLE
Add flag min_time_limit to evalutor

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -169,9 +169,9 @@ def untrusted_check(
     atol,
     ref_time: List[float],
     fast_check: bool = False,
+    min_time_limit: float = 0.1,
 ) -> Tuple[str, np.ndarray]:
-    min_limit = 0.05
-    time_limits = [max(min_limit, 2 * t) for t in ref_time]
+    time_limits = [max(min_time_limit, 2 * t) for t in ref_time]
     timeout = sum(time_limits) + 1
     if not fast_check:
         timeout += 1  # extra time for data collection
@@ -227,6 +227,7 @@ def evaluate_files(
     atol: float,
     ref_time: List[float],
     fast_check: bool = False,
+    min_time_limit: float = 0.1,
 ) -> List[Tuple[str, List[bool]]]:
     ret = []
     # sort files by the id in name (i.e., "../n.py")
@@ -241,6 +242,7 @@ def evaluate_files(
             atol=atol,
             ref_time=ref_time,
             fast_check=fast_check,
+            min_time_limit=min_time_limit,
         )
         ret.append((stat, det.tolist()))
     return ret

--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -74,6 +74,7 @@ def check_correctness(
     base_only=False,
     fast_check=False,
     identifier=None,
+    min_time_limit: float = 0.1,
 ) -> Dict[str, Union[int, Optional[Result]]]:
     ret = {
         "completion_id": completion_id,
@@ -88,6 +89,7 @@ def check_correctness(
         atol=problem["atol"],
         ref_time=expected_output["base_time"],
         fast_check=fast_check,
+        min_time_limit=min_time_limit,
     )
 
     if not base_only:
@@ -99,6 +101,7 @@ def check_correctness(
             atol=problem["atol"],
             ref_time=expected_output["plus_time"],
             fast_check=fast_check,
+            min_time_limit=min_time_limit,
         )
 
     return ret
@@ -158,6 +161,7 @@ def evaluate_humaneval(flags):
                     flags.base_only,
                     not flags.test_details,  # fast_check
                     sample["_identifier"],
+                    flags.min_time_limit,
                 )
                 futures.append(executor.submit(check_correctness, *args))
                 completion_id[task_id] += 1
@@ -256,6 +260,7 @@ def main():
     parser.add_argument("--parallel", default=None, type=int)
     parser.add_argument("--i-just-wanna-run", action="store_true")
     parser.add_argument("--test-details", action="store_true")
+    parser.add_argument("--min-time-limit", default=0.1, type=float)
     parser.add_argument("--mini", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
cc: @tju01

As a quick workaround, allow users to set a minimal time limit from command-line and increase the minimal timeout to 100 milliseconds.

link: #5