### PR TITLE
add flag `gt_multiplier` to evaluator

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -170,9 +170,9 @@ def untrusted_check(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
-    gt_timelimit_multiplier: float = 2.0,
+    gt_time_limit_factor: float = 2.0,
 ) -> Tuple[str, np.ndarray]:
-    time_limits = [max(min_time_limit, gt_timelimit_multiplier * t) for t in ref_time]
+    time_limits = [max(min_time_limit, gt_time_limit_factor * t) for t in ref_time]
     timeout = sum(time_limits) + 1
     if not fast_check:
         timeout += 1  # extra time for data collection
@@ -229,7 +229,7 @@ def evaluate_files(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
-    gt_timelimit_multiplier: float = 2.0,
+    gt_time_limit_factor: float = 2.0,
 ) -> List[Tuple[str, List[bool]]]:
     ret = []
     # sort files by the id in name (i.e., "../n.py")
@@ -245,7 +245,7 @@ def evaluate_files(
             ref_time=ref_time,
             fast_check=fast_check,
             min_time_limit=min_time_limit,
-            gt_timelimit_multiplier=gt_timelimit_multiplier,
+            gt_time_limit_factor=gt_time_limit_factor,
         )
         ret.append((stat, det.tolist()))
     return ret

--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -170,8 +170,9 @@ def untrusted_check(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
+    gt_multiplier: float = 2.0,
 ) -> Tuple[str, np.ndarray]:
-    time_limits = [max(min_time_limit, 2 * t) for t in ref_time]
+    time_limits = [max(min_time_limit, gt_multiplier * t) for t in ref_time]
     timeout = sum(time_limits) + 1
     if not fast_check:
         timeout += 1  # extra time for data collection
@@ -228,6 +229,7 @@ def evaluate_files(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
+    gt_multiplier: float = 2.0,
 ) -> List[Tuple[str, List[bool]]]:
     ret = []
     # sort files by the id in name (i.e., "../n.py")
@@ -243,6 +245,7 @@ def evaluate_files(
             ref_time=ref_time,
             fast_check=fast_check,
             min_time_limit=min_time_limit,
+            gt_multiplier=gt_multiplier,
         )
         ret.append((stat, det.tolist()))
     return ret

--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -170,9 +170,9 @@ def untrusted_check(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
-    gt_multiplier: float = 2.0,
+    gt_timelimit_multiplier: float = 2.0,
 ) -> Tuple[str, np.ndarray]:
-    time_limits = [max(min_time_limit, gt_multiplier * t) for t in ref_time]
+    time_limits = [max(min_time_limit, gt_timelimit_multiplier * t) for t in ref_time]
     timeout = sum(time_limits) + 1
     if not fast_check:
         timeout += 1  # extra time for data collection
@@ -229,7 +229,7 @@ def evaluate_files(
     ref_time: List[float],
     fast_check: bool = False,
     min_time_limit: float = 0.1,
-    gt_multiplier: float = 2.0,
+    gt_timelimit_multiplier: float = 2.0,
 ) -> List[Tuple[str, List[bool]]]:
     ret = []
     # sort files by the id in name (i.e., "../n.py")
@@ -245,7 +245,7 @@ def evaluate_files(
             ref_time=ref_time,
             fast_check=fast_check,
             min_time_limit=min_time_limit,
-            gt_multiplier=gt_multiplier,
+            gt_timelimit_multiplier=gt_timelimit_multiplier,
         )
         ret.append((stat, det.tolist()))
     return ret

--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -75,7 +75,7 @@ def check_correctness(
     fast_check=False,
     identifier=None,
     min_time_limit: float = 0.1,
-    gt_timelimit_multiplier: float = 2.0,
+    gt_time_limit_factor: float = 2.0,
 ) -> Dict[str, Union[int, Optional[Result]]]:
     ret = {
         "completion_id": completion_id,
@@ -91,7 +91,7 @@ def check_correctness(
         ref_time=expected_output["base_time"],
         fast_check=fast_check,
         min_time_limit=min_time_limit,
-        gt_timelimit_multiplier=gt_timelimit_multiplier,
+        gt_time_limit_factor=gt_time_limit_factor,
     )
 
     if not base_only:
@@ -104,7 +104,7 @@ def check_correctness(
             ref_time=expected_output["plus_time"],
             fast_check=fast_check,
             min_time_limit=min_time_limit,
-            gt_timelimit_multiplier=gt_timelimit_multiplier,
+            gt_time_limit_factor=gt_time_limit_factor,
         )
 
     return ret
@@ -165,7 +165,7 @@ def evaluate_humaneval(flags):
                     not flags.test_details,  # fast_check
                     sample["_identifier"],
                     flags.min_time_limit,
-                    flags.gt_timelimit_multiplier,
+                    flags.gt_time_limit_factor,
                 )
                 futures.append(executor.submit(check_correctness, *args))
                 completion_id[task_id] += 1
@@ -265,7 +265,7 @@ def main():
     parser.add_argument("--i-just-wanna-run", action="store_true")
     parser.add_argument("--test-details", action="store_true")
     parser.add_argument("--min-time-limit", default=0.1, type=float)
-    parser.add_argument("--gt-timelimit-multiplier", default=2.0, type=float)
+    parser.add_argument("--gt-time-limit-factor", default=2.0, type=float)
     parser.add_argument("--mini", action="store_true")
     args = parser.parse_args()
 

--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -75,6 +75,7 @@ def check_correctness(
     fast_check=False,
     identifier=None,
     min_time_limit: float = 0.1,
+    gt_multiplier: float = 2.0,
 ) -> Dict[str, Union[int, Optional[Result]]]:
     ret = {
         "completion_id": completion_id,
@@ -90,6 +91,7 @@ def check_correctness(
         ref_time=expected_output["base_time"],
         fast_check=fast_check,
         min_time_limit=min_time_limit,
+        gt_multiplier=gt_multiplier,
     )
 
     if not base_only:
@@ -102,6 +104,7 @@ def check_correctness(
             ref_time=expected_output["plus_time"],
             fast_check=fast_check,
             min_time_limit=min_time_limit,
+            gt_multiplier=gt_multiplier,
         )
 
     return ret
@@ -162,6 +165,7 @@ def evaluate_humaneval(flags):
                     not flags.test_details,  # fast_check
                     sample["_identifier"],
                     flags.min_time_limit,
+                    flags.gt_multiplier,
                 )
                 futures.append(executor.submit(check_correctness, *args))
                 completion_id[task_id] += 1
@@ -261,6 +265,7 @@ def main():
     parser.add_argument("--i-just-wanna-run", action="store_true")
     parser.add_argument("--test-details", action="store_true")
     parser.add_argument("--min-time-limit", default=0.1, type=float)
+    parser.add_argument("--gt-multiplier", default=2.0, type=float)
     parser.add_argument("--mini", action="store_true")
     args = parser.parse_args()
 

--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -75,7 +75,7 @@ def check_correctness(
     fast_check=False,
     identifier=None,
     min_time_limit: float = 0.1,
-    gt_multiplier: float = 2.0,
+    gt_timelimit_multiplier: float = 2.0,
 ) -> Dict[str, Union[int, Optional[Result]]]:
     ret = {
         "completion_id": completion_id,
@@ -91,7 +91,7 @@ def check_correctness(
         ref_time=expected_output["base_time"],
         fast_check=fast_check,
         min_time_limit=min_time_limit,
-        gt_multiplier=gt_multiplier,
+        gt_timelimit_multiplier=gt_timelimit_multiplier,
     )
 
     if not base_only:
@@ -104,7 +104,7 @@ def check_correctness(
             ref_time=expected_output["plus_time"],
             fast_check=fast_check,
             min_time_limit=min_time_limit,
-            gt_multiplier=gt_multiplier,
+            gt_timelimit_multiplier=gt_timelimit_multiplier,
         )
 
     return ret
@@ -165,7 +165,7 @@ def evaluate_humaneval(flags):
                     not flags.test_details,  # fast_check
                     sample["_identifier"],
                     flags.min_time_limit,
-                    flags.gt_multiplier,
+                    flags.gt_timelimit_multiplier,
                 )
                 futures.append(executor.submit(check_correctness, *args))
                 completion_id[task_id] += 1
@@ -265,7 +265,7 @@ def main():
     parser.add_argument("--i-just-wanna-run", action="store_true")
     parser.add_argument("--test-details", action="store_true")
     parser.add_argument("--min-time-limit", default=0.1, type=float)
-    parser.add_argument("--gt-multiplier", default=2.0, type=float)
+    parser.add_argument("--gt-timelimit-multiplier", default=2.0, type=float)
     parser.add_argument("--mini", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
Users are allowed to fully configure the time limit. If `gt_multiplier=K`, then the time limit would be `max(min_time_limit, K * gt_time)`.
Partly resolve #5.