### PR TITLE
Fix broken evalplus

### DIFF
--- a/evalplus/data/__init__.py
+++ b/evalplus/data/__init__.py
@@ -15,7 +15,7 @@ CACHE_DIR = user_cache_dir("evalplus")
 HUMANEVAL_URL = (
     "https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz"
 )
-HUMANEVAL_PLUS_VERSION = "v0.1.9"
+HUMANEVAL_PLUS_VERSION = "v0.1.8"
 
 
 def get_dataset_metadata(name, version, mini):


### PR DESCRIPTION
Kept getting this error:

```
Traceback (most recent call last):
  File "/mnt/data/FastEval/.venv/bin/evalplus.evaluate", line 8, in <module>
    sys.exit(main())
  File "/mnt/data/FastEval/.venv/src/evalplus/evalplus/evaluate.py", line 275, in main
    evaluate_humaneval(args)
  File "/mnt/data/FastEval/.venv/src/evalplus/evalplus/evaluate.py", line 136, in evaluate_humaneval
    expected_output = get_groundtruth(problems, dataset_hash)
  File "/mnt/data/FastEval/.venv/src/evalplus/evalplus/evaluate.py", line 48, in get_groundtruth
    oracle["base"], oracle["base_time"] = trusted_exec(
  File "/mnt/data/FastEval/.venv/src/evalplus/evalplus/gen/util/__init__.py", line 7, in trusted_exec
    exec(code, exec_globals)
  File "<string>", line 39
    ans = 0    
               ^
IndentationError: unindent does not match any outer indentation level
```

Was only able to fix it by changing HUMANEVAL_PLUS_VERSION = "v0.1.9" ->  "v0.1.8"