### PR TITLE
feat[port]: port MBPP+ to the original-MBPP-like format

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -148,7 +148,10 @@ def unsafe_execute(
                             elif entry_point in MBPP_OUTPUT_NOT_NONE_TASKS:
                                 # exp is True  if not None
                                 #        False if None
-                                exact_match = exp == (out is not None)
+                                if isinstance(out, bool):
+                                    exact_match = out == exp
+                                else:
+                                    exact_match = exp == (out is not None)
 
                         if dataset == "humaneval":
                             if "find_zero" == entry_point:

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -195,7 +195,7 @@ def main():
     if args.debug_tasks:
         for problem in compatible_problems.values():
             print("--- debugging:", problem["task_id"])
-            print(problem["prompt"] + problem["canonical_solution"])
+            print(problem["prompt"] + problem["code"])
             test_code = problem["test"]
             if len(test_code) <= 2048 + 512:
                 print(test_code)

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -25,7 +25,7 @@ MBPP_TEST_TEMPLATE = """\
 inputs = {inputs}
 results = {results}
 for i, (inp, exp) in enumerate(zip(inputs, results)):
-    {assertion}
+    assertion({entry_point}(*inp), exp, {atol})
 """
 
 MBPP_CROSSCHECK_TEMPLATE = """\
@@ -35,7 +35,7 @@ MBPP_CROSSCHECK_TEMPLATE = """\
 
 inputs = {inputs}
 for i, inp in enumerate(inputs):
-    assertion(candidate(*inp), ref_func(*inp), {atol})
+    assertion({entry_point}(*inp), ref_func(*inp), {atol})
 """
 
 ASSERTION_FN = f"""\
@@ -62,6 +62,7 @@ def synthesize_test_code(task_id, entry_point, inputs, results, ref_func, atol):
             aux_fn=ASSERTION_FN,
             inputs=inputs,
             ref_func=ref_func.replace(f" {entry_point}(", " ref_func("),
+            entry_point=entry_point,
             atol=atol,
         )
 
@@ -78,7 +79,8 @@ def synthesize_test_code(task_id, entry_point, inputs, results, ref_func, atol):
         aux_fn=aux_fn,
         inputs=inputs,
         results=results,
-        assertion=f"assertion(candidate(*inp), exp, {atol})",
+        entry_point=entry_point,
+        atol=atol,
     )
 
     return task_id, test_code
@@ -187,9 +189,9 @@ def main():
     if args.debug_tasks:
         for problem in compatible_problems.values():
             print("--- debugging:", problem["task_id"])
-            print(problem["prompt"] + problem["code"])
+            print('"""\n' + problem["prompt"] + '\n"""\n' + problem["code"])
             test_code = problem["test"]
-            if len(test_code) <= 2048 + 512:
+            if True or len(test_code) <= 2048 + 512:
                 print(test_code)
             else:
                 print(problem["test"][:1024], "...")

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -1,0 +1,221 @@
+import ast
+import inspect
+import json
+import multiprocessing
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+from tqdm import tqdm
+
+from evalplus.data.mbpp import MBPP_PLUS_VERSION, get_mbpp_plus, get_mbpp_plus_hash
+from evalplus.eval import is_floats
+from evalplus.eval._special_oracle import MBPP_OUTPUT_NOT_NONE_TASKS
+from evalplus.evaluate import get_groundtruth
+
+MBPP_TEST_TEMPLATE = """\
+{imports}
+
+{aux_fn}
+
+def check(candidate):
+    inputs = {inputs}
+    results = {results}
+    for i, (inp, exp) in enumerate(zip(inputs, results)):
+        {assertion}
+"""
+
+MBPP_CROSSCHECK_TEMPLATE = """\
+{aux_fn}
+
+{ref_func}
+
+def check(candidate):
+    inputs = {inputs}
+    for i, inp in enumerate(inputs):
+        assertion(candidate(*inp), ref_func(*inp), {atol})
+"""
+
+ASSERTION_FN = f"""\
+import numpy as np
+
+{inspect.getsource(is_floats)}
+
+def assertion(out, exp, atol):
+    exact_match = out == exp
+
+    if atol == 0 and is_floats(exp):
+        atol = 1e-6
+    if not exact_match and atol != 0:
+        np.testing.assert_allclose(out, exp, atol=atol)
+    else:
+        assert exact_match
+"""
+
+
+def synthesize_test_code(task_id, entry_point, inputs, results, ref_func, atol):
+    # dataset size optimization for large outputs
+    if entry_point in (
+        "combinations_colors",  # too big
+        "freq_count",  # collections.Counter exists in results
+        # Mbpp/271 timeout in human-eval framework
+    ):
+        return task_id, MBPP_CROSSCHECK_TEMPLATE.format(
+            aux_fn=ASSERTION_FN,
+            inputs=inputs,
+            ref_func=ref_func.replace(f" {entry_point}(", " ref_func("),
+            atol=atol,
+        )
+
+    # default settings
+    imports = set()
+    aux_fn = ASSERTION_FN
+    assertion = f"assertion(candidate(*inp), exp, {atol})"
+
+    test_code = MBPP_TEST_TEMPLATE.format(
+        imports="\n".join(imports),
+        aux_fn=aux_fn,
+        inputs=inputs,
+        results=results,
+        assertion=assertion,
+    )
+
+    # inf exists in inputs/results
+    if entry_point in (
+        "zero_count",
+        "minimum",
+    ):
+        test_code = "from math import inf\n" + test_code
+
+    return task_id, test_code
+
+
+def deduplicate(inputs, results):
+    assert len(inputs) == len(results)
+    unique_input_strs = set([f"{x}" for x in inputs])
+
+    new_inputs, new_results = [], []
+    for inp, res in zip(inputs, results):
+        inp_str = f"{inp}"
+        if inp_str in unique_input_strs:
+            new_inputs.append(inp)
+            new_results.append(res)
+            unique_input_strs.remove(inp_str)
+
+    return new_inputs, new_results
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug-tasks", nargs="+", default=[], type=int)
+
+    args = parser.parse_args()
+
+    if hasattr(sys, "set_int_max_str_digits"):
+        sys.set_int_max_str_digits(int(10e8))
+
+    plus_problems = get_mbpp_plus(mini=False)
+    dataset_hash = get_mbpp_plus_hash()
+
+    compatible_problems = {}
+    expected_outputs = get_groundtruth(
+        plus_problems, dataset_hash, MBPP_OUTPUT_NOT_NONE_TASKS
+    )
+
+    # debugging: monitoring test code size
+    id2bytes = {}
+
+    n_workers = max(1, multiprocessing.cpu_count() // 4)
+    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+        futures = []
+        for task_id, plus_form in tqdm(plus_problems.items()):
+            if args.debug_tasks and int(task_id.split("/")[-1]) not in args.debug_tasks:
+                continue
+
+            # special case for Mbpp/56, whose entry point is "check"
+            # we need to replace it with "check_reverse_twice"
+            # but llm-produced samples are still using "check" as entry point
+            # (released on https://github.com/evalplus/evalplus/releases/tag/v0.2.0)
+            if task_id == "Mbpp/56":
+                plus_form["prompt"] = plus_form["prompt"].replace(
+                    "check(", "check_reverse_twice("
+                )
+                plus_form["canonical_solution"] = plus_form[
+                    "canonical_solution"
+                ].replace("check(", "check_reverse_twice(")
+                plus_form["entry_point"] = "check_reverse_twice"
+
+            compatible_form = {}
+            compatible_form["task_id"] = task_id
+            compatible_form["prompt"] = plus_form["prompt"]
+            compatible_form["canonical_solution"] = plus_form["canonical_solution"]
+            compatible_form["entry_point"] = plus_form["entry_point"]
+            compatible_problems[task_id] = compatible_form
+
+            inputs = (
+                plus_form["base_input"] + plus_form["plus_input"]
+                if len(plus_form["plus_input"]) > 0
+                else plus_form["base_input"]
+            )
+            results = (
+                expected_outputs[task_id]["base"] + expected_outputs[task_id]["plus"]
+            )
+
+            inputs, results = deduplicate(inputs, results)
+
+            assert len(inputs) == len(results)
+            atol = plus_form["atol"]
+
+            simplified_prompt = ""
+            for line in compatible_form["prompt"].split("\n"):
+                if not line:
+                    continue
+                if '"""' in line or "'''" in line:
+                    break
+                simplified_prompt += line + "\n"
+
+            futures.append(
+                executor.submit(
+                    synthesize_test_code,
+                    task_id,
+                    compatible_form["entry_point"],
+                    inputs,
+                    results,
+                    simplified_prompt + compatible_form["canonical_solution"],
+                    atol,
+                )
+            )
+
+        for future in tqdm(as_completed(futures), total=len(plus_problems)):
+            task_id, test_code = future.result()
+            # syntax check of test_code
+            ast.parse(test_code)
+            id2bytes[task_id] = len(test_code.encode("utf-8"))
+            compatible_problems[task_id]["test"] = test_code
+
+    # print the top-10 largest test code
+    print("Top-10 largest test code comes from problems (in megabytes):")
+    for task_id, size in sorted(id2bytes.items(), key=lambda x: x[1], reverse=True)[
+        :10
+    ]:
+        print(f"{task_id}:\t{size / 1024 / 1024:.2f}mb")
+
+    if args.debug_tasks:
+        for problem in compatible_problems.values():
+            print("--- debugging:", problem["task_id"])
+            print(problem["prompt"] + problem["canonical_solution"])
+            test_code = problem["test"]
+            if len(test_code) <= 2048 + 512:
+                print(test_code)
+            else:
+                print(problem["test"][:1024], "...")
+                print("...", problem["test"][-1024:])
+    else:
+        with open(f"MbppPlus-OriginFmt-{MBPP_PLUS_VERSION}.jsonl", "w") as f:
+            for problem in compatible_problems.values():
+                f.write(json.dumps(problem) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -136,8 +136,8 @@ def main():
 
             compatible_form = {
                 "task_id": task_id_int,
-                "prompt": plus_form["prompt"],
                 "code": plus_form["canonical_solution"],
+                "prompt": original_mbpp[str(task_id_int)]["prompt"],
                 "source_file": original_mbpp[str(task_id_int)]["source_file"],
                 "test_imports": original_mbpp[str(task_id_int)]["test_imports"],
                 "test_list": original_mbpp[str(task_id_int)]["test_list"],
@@ -158,14 +158,6 @@ def main():
             assert len(inputs) == len(results)
             atol = plus_form["atol"]
 
-            simplified_prompt = ""
-            for line in compatible_form["prompt"].split("\n"):
-                if not line:
-                    continue
-                if '"""' in line or "'''" in line:
-                    break
-                simplified_prompt += line + "\n"
-
             futures.append(
                 executor.submit(
                     synthesize_test_code,
@@ -173,7 +165,7 @@ def main():
                     plus_form["entry_point"],
                     inputs,
                     results,
-                    simplified_prompt + compatible_form["code"],
+                    compatible_form["code"],
                     atol,
                 )
             )


### PR DESCRIPTION
This pr tried to implement feat mentioned in #55 

MbppPlus part

Use released gpt-4's samples (https://github.com/evalplus/evalplus/releases/download/v0.2.0/gpt-4-1106-preview_temp_0.0.zip) and converted into a json file.

Compiled dataset and samples can be used in Human-eval framework right now.
Also used evalplus to validate the results.

<img width="1163" alt="image" src="https://github.com/evalplus/evalplus/assets/78358442/4d57dd59-84ac-4b97-a925-90b4074c9674">

- Inconsistent task: "Mbpp/56" has entry point named "check", which introduces conflict with test code.

