### PR TITLE
fix: skip empty solutions

### DIFF
--- a/tools/sanitize.py
+++ b/tools/sanitize.py
@@ -144,7 +144,9 @@ if __name__ == "__main__":
         bodies = [
             chunk for chunk in chunks[1:] if "    return " in chunk.split("\ndef")[0]
         ]
-        new_code = def_left + def_left.join(bodies)  # fn + impl
+        new_code = (
+            def_left + def_left.join(bodies) if len(bodies) > 0 else ""
+        )  # fn + impl
         new_code = to_four_space_indents(new_code)
 
         for eof in args.eofs:


### PR DESCRIPTION
When sanitizing samples with an empty solution, 
<img width="607" alt="image" src="https://github.com/evalplus/evalplus/assets/78358442/6ba07a42-6601-475b-bc59-d3f0571213f1">

It adds the def_code, which is unexpected,
<img width="578" alt="image" src="https://github.com/evalplus/evalplus/assets/78358442/c00fb345-9e2f-4798-9fda-a339c71277d0">
We should skip this case.