### PR TITLE
fix(eval): use `assert np.allclose` to replace `np.testing.assert_allclose`

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -169,7 +169,9 @@ def unsafe_execute(
                     if atol == 0 and is_floats(exp):
                         atol = 1e-6  # enforce atol for float comparison
                     if not exact_match and atol != 0:
-                        np.testing.assert_allclose(out, exp, atol=atol)
+                        # explicitly set rtol=1e-07
+                        # to match `np.testing.assert_allclose`'s default values
+                        assert np.allclose(out, exp, rtol=1e-07, atol=atol)
                     else:
                         assert exact_match
                 except BaseException:

--- a/tools/humaneval/to_original_fmt.py
+++ b/tools/humaneval/to_original_fmt.py
@@ -50,7 +50,7 @@ def assertion(out, exp, atol):
     if atol == 0 and is_floats(exp):
         atol = 1e-6
     if not exact_match and atol != 0:
-        np.testing.assert_allclose(out, exp, atol=atol)
+        assert np.allclose(out, exp, rtol=1e-07, atol=atol)
     else:
         assert exact_match
 """

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -55,7 +55,7 @@ def assertion(out, exp, atol):
     if atol == 0 and is_floats(exp):
         atol = 1e-6
     if out != exp and atol != 0:
-        np.testing.assert_allclose(out, exp, atol=atol)
+        assert np.all_close(out, exp, atol=atol)
     else:
         assert out == exp, f"out: {{out}}, exp: {{exp}}"
 """
@@ -88,7 +88,7 @@ def assertion(out, exp, atol):
     out = set(out)
     exp = set(exp)
     if out != exp and atol != 0:
-        np.testing.assert_allclose(out, exp, atol=atol)
+        assert np.allclose(out, exp, rtol=1e-07, atol=atol)
     else:
         assert out == exp, f"out: {{out}}, exp: {{exp}}"
 """

--- a/tools/mbpp/to_original_fmt.py
+++ b/tools/mbpp/to_original_fmt.py
@@ -55,7 +55,7 @@ def assertion(out, exp, atol):
     if atol == 0 and is_floats(exp):
         atol = 1e-6
     if out != exp and atol != 0:
-        assert np.all_close(out, exp, atol=atol)
+        assert np.allclose(out, exp, rtol=1e-07, atol=atol)
     else:
         assert out == exp, f"out: {{out}}, exp: {{exp}}"
 """


### PR DESCRIPTION
trying to fix #157
use `np.allclose` instead of `np.testing.assert_allclose` to avoid creating a subprocess

```shell
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> subprocess.Popen = None
>>> import numpy as np
>>> assert np.allclose([1, 2], [1, 2])
>>> assert np.allclose([1, 2], [1, 1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> np.testing
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/junhao/miniconda3/envs/evalperf/lib/python3.10/site-packages/numpy/__init__.py", line 327, in __getattr__
    import numpy.testing as testing
  File "/home/junhao/miniconda3/envs/evalperf/lib/python3.10/site-packages/numpy/testing/__init__.py", line 11, in <module>
    from ._private.utils import *
  File "/home/junhao/miniconda3/envs/evalperf/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1253, in <module>
    _SUPPORTS_SVE = check_support_sve()
  File "/home/junhao/miniconda3/envs/evalperf/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1247, in check_support_sve
    output = subprocess.run(cmd, capture_output=True, text=True)
  File "/home/junhao/miniconda3/envs/evalperf/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
TypeError: 'NoneType' object is not callable
```