### PR TITLE
fix: show the first failed case when `--test-details` is not enabled

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -175,11 +175,10 @@ def unsafe_execute(
                     else:
                         assert exact_match
                 except BaseException:
-                    if fast_check:
-                        raise
-
                     details[i] = False
                     progress.value += 1
+                    if fast_check:
+                        raise
                     continue
 
                 details[i] = True


### PR DESCRIPTION
Previously, without `--test-details`, the evaluation results do not even show the first failed case, which is inconvenient for debugging.