### PR TITLE
fix: showing the only and the last fail test, `is_float`

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -96,7 +96,7 @@ def is_floats(x) -> bool:
     # check if it is float; List[float]; Tuple[float]
     if isinstance(x, float):
         return True
-    if isinstance(x, (list, tuple)):
+    if isinstance(x, (list, tuple)) and x:
         return all(isinstance(i, float) for i in x)
     if isinstance(x, np.ndarray):
         return x.dtype == np.float64 or x.dtype == np.float32

--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -171,6 +171,9 @@ def unsafe_execute(
                     if not exact_match and atol != 0:
                         # explicitly set rtol=1e-07
                         # to match `np.testing.assert_allclose`'s default values
+                        assert type(out) == type(exp)
+                        if isinstance(exp, (list, tuple)):
+                            assert len(out) == len(exp)
                         assert np.allclose(out, exp, rtol=1e-07, atol=atol)
                     else:
                         assert exact_match

--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -241,8 +241,8 @@ def evaluate(flags):
                             inputs[i] for i in range(len(details)) if not details[i]
                         ]
 
-                    # esle => simply return the only and the last fail test
-                    return [inputs[len(details)]]
+                    # else => simply return the only and the last fail test
+                    return [inputs[len(details) - 1]]
 
                 base_stat, base_details = res["base"]
                 base_fail_tests = get_failed_tests(


### PR DESCRIPTION
Fix the following issues:

```python
import numpy as np

assert all(isinstance(i, float) for i in []) == True

assert np.allclose([], [1.1], rtol=1e-07, atol=1e-6) == True
assert np.allclose(1.1, [1.1], rtol=1e-07, atol=1e-6) == True
```