### PR TITLE
fix: correctness check for `find_zero`

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -162,7 +162,8 @@ def unsafe_execute(
 
                     if dataset == "humaneval":
                         if "find_zero" == entry_point:
-                            assert _poly(*inp, out) <= atol
+                            assert abs(_poly(*inp, out)) <= atol
+                            continue
                     # ============== special oracles ================= #
                     # ================================================ #
 


### PR DESCRIPTION
- Should use `abs` to make sure the result is near zero.
- Should use `continue` to skip the following regular checks for other problems. Otherwise, even a correct one passes this assertion, it may fail when applying other checks which are incompatible to this problem.