### PR TITLE
Don't limit memory in code evaluation

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -127,8 +127,7 @@ def unsafe_execute(
         rmdir = os.rmdir
         chdir = os.chdir
         # Disable functionalities that can make destructive changes to the test.
-        # allow only 4GB memory usage
-        maximum_memory_bytes = 4 * 1024 * 1024 * 1024
+        maximum_memory_bytes = None
         reliability_guard(maximum_memory_bytes=maximum_memory_bytes)
         exec_globals = {}
         try:


### PR DESCRIPTION
In the bigcode harness they do not set memory limits when executing code: https://github.com/bigcode-project/bigcode-evaluation-harness/blob/0f3e95f0806e78a4f432056cdb1be93604a51d69/bigcode_eval/tasks/custom_metrics/execute.py#L69 . Setting a large memory and stack limit like evalplus does will lead to exceptions when the environment that we are executing in has hard limits that are lower than the 4GB limit. It would be better to just respect the existing environment hard limits.