### PR TITLE
feat(eval): Saving pass@k in result output

### DIFF
--- a/evalplus/evaluate.py
+++ b/evalplus/evaluate.py
@@ -322,6 +322,7 @@ def evaluate(
     cprint(f"{dataset} (base tests)", "red")
     for k, v in pass_at_k.items():
         cprint(f"{k}:\t{v:.3f}", "red")
+    results["pass_at_k"] = {"base": pass_at_k}
 
     if new_correct:
         cprint(f"{dataset}+ (base + extra tests)", "green")
@@ -332,6 +333,7 @@ def evaluate(
         }
         for k, v in pass_at_k.items():
             cprint(f"{k}:\t{v:.3f}", "green")
+        results["pass_at_k"]["plus"] = pass_at_k
 
     # save results
     if os.path.isfile(result_path) and i_just_wanna_run:


### PR DESCRIPTION
Added `pass_at_k` dicts (base and plus if available) to `result` for reusing calculated pass@k in external tools, etc.