### PR TITLE
Improve flexibility for custom URLs and tokenizer loading

### DIFF
--- a/evalplus/codegen.py
+++ b/evalplus/codegen.py
@@ -127,6 +127,7 @@ def run_codegen(
     backend: str = "vllm",
     force_base_prompt: bool = False,
     base_url: str = None,
+    verify_certificate: bool = True,
     tp: int = 1,
     evalperf_type: str = None,  # For EvalPerf
     jsonl_fmt: bool = True,
@@ -230,6 +231,7 @@ def run_codegen(
         force_base_prompt=force_base_prompt,
         dataset=dataset,
         base_url=base_url,
+        verify_certificate=verify_certificate,
         tp=tp,
         instruction_prefix=instruction_prefix,
         response_prefix=response_prefix,

--- a/evalplus/codegen.py
+++ b/evalplus/codegen.py
@@ -138,7 +138,8 @@ def run_codegen(
     enable_chunked_prefill: bool = False,
     dtype: str = "bfloat16",
     gptqmodel_backend: str = "auto",  # For GPTQModel
-    gguf_file: Optional[str] = None
+    gguf_file: Optional[str] = None,
+    use_fast_tokenizer: bool = False
 ):
     assert dataset in ["humaneval", "mbpp", "evalperf"], f"Invalid dataset {dataset}"
     assert evalperf_type is None or evalperf_type in [
@@ -243,6 +244,7 @@ def run_codegen(
         dtype=dtype,
         gptqmodel_backend=gptqmodel_backend,
         gguf_file=gguf_file,
+        use_fast_tokenizer=use_fast_tokenizer
     )
 
     codegen(

--- a/evalplus/provider/__init__.py
+++ b/evalplus/provider/__init__.py
@@ -20,6 +20,7 @@ def make_model(
     enable_chunked_prefill=False,
     # openai only
     base_url=None,
+    verify_certificate=True,
     # hf only
     attn_implementation="eager",
     device_map=None,
@@ -71,6 +72,7 @@ def make_model(
             batch_size=batch_size,
             temperature=temperature,
             base_url=base_url,
+            verify_certificate=verify_certificate,
             instruction_prefix=instruction_prefix,
             response_prefix=response_prefix,
         )

--- a/evalplus/provider/__init__.py
+++ b/evalplus/provider/__init__.py
@@ -27,6 +27,7 @@ def make_model(
     # gptqmodel only
     gptqmodel_backend: str = 'auto',
     gguf_file: str = None,
+    use_fast_tokenizer: bool = False
 ) -> DecoderBase:
     if backend == "vllm":
         from evalplus.provider.vllm import VllmDecoder
@@ -44,7 +45,8 @@ def make_model(
             enable_prefix_caching=enable_prefix_caching,
             enable_chunked_prefill=enable_chunked_prefill,
             dtype=dtype,
-            gguf_file=gguf_file
+            gguf_file=gguf_file,
+            use_fast_tokenizer= use_fast_tokenizer
         )
     elif backend == "hf":
         from evalplus.provider.hf import HuggingFaceDecoder

--- a/evalplus/provider/openai.py
+++ b/evalplus/provider/openai.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 
+import httpx
 import openai
 
 from evalplus.gen.util import openai_request
@@ -9,9 +10,10 @@ from evalplus.provider.utility import concurrent_call
 
 
 class OpenAIChatDecoder(DecoderBase):
-    def __init__(self, name: str, base_url=None, **kwargs) -> None:
+    def __init__(self, name: str, base_url=None, verify_certificate=True, **kwargs) -> None:
         super().__init__(name, **kwargs)
         self.base_url = base_url
+        self.verify_certificate = verify_certificate
 
     def codegen(
         self, prompt: str, do_sample: bool = True, num_samples: int = 200
@@ -29,7 +31,11 @@ class OpenAIChatDecoder(DecoderBase):
 
     def _codegen_api_batch(self, prompt: str, batch_size: int) -> List[str]:
         client = openai.OpenAI(
-            api_key=os.getenv("OPENAI_API_KEY", "none"), base_url=self.base_url
+            api_key=os.getenv("OPENAI_API_KEY", "none"),
+            base_url=self.base_url,
+            http_client= httpx.Client(
+                verify=self.verify_certificate
+            )
         )
 
         ret = openai_request.make_auto_request(

--- a/evalplus/provider/vllm.py
+++ b/evalplus/provider/vllm.py
@@ -20,6 +20,7 @@ class VllmDecoder(DecoderBase):
         enable_prefix_caching=False,
         enable_chunked_prefill=False,
         gguf_file: str = None,
+        use_fast_tokenizer: bool = False,
         **kwargs
     ) -> None:
         super().__init__(name, **kwargs)
@@ -36,7 +37,7 @@ class VllmDecoder(DecoderBase):
         # gguf format embeds tokenizer and is not compatible with hf tokenizer `use_fast` param
         tokenizer_kwargs = {}
         if gguf_file is None:
-            tokenizer_kwargs["use_fast"] = False
+            tokenizer_kwargs["use_fast"] = use_fast_tokenizer
         else:
             tokenizer_kwargs["gguf_file"] = gguf_file
         self.tokenizer = AutoTokenizer.from_pretrained(self.name, **tokenizer_kwargs)


### PR DESCRIPTION
This PR addresses two limitations in the current configuration:

1.  **Optional SSL Certificate Verification:**
    *   **Problem:** Connecting to custom model URLs currently requires strict SSL certificate validation, blocking evaluations if the endpoint uses self-signed or invalid certificates.
    *   **Solution:** Introduced `verify_certificate` parameter (defaults to `True`). Setting it to `False` bypasses SSL verification, enabling evaluation against a wider range of deployed model endpoints.

2.  **Configurable `use_fast` for Tokenizer:**
    *   **Problem:** The tokenizer loading logic previously had fixed behavior regarding the `use_fast` flag (sometimes defaulting to `False` based on internal checks like GGUF file presence). This lack of control led to loading exceptions for certain models, particularly when loaded from local paths.
    *   **Solution:** Added a `use_fast_tokenizer` parameter (defaults to `False`). This externalizes control over using the fast tokenizer, resolving loading issues by allowing users to specify the appropriate setting for their model.