### PR TITLE
Allow bypassing SSL verification for custom model URLs

### DIFF
--- a/evalplus/codegen.py
+++ b/evalplus/codegen.py
@@ -127,6 +127,7 @@ def run_codegen(
     backend: str = "vllm",
     force_base_prompt: bool = False,
     base_url: str = None,
+    verify_certificate: bool = True,
     tp: int = 1,
     evalperf_type: str = None,  # For EvalPerf
     jsonl_fmt: bool = True,
@@ -230,6 +231,7 @@ def run_codegen(
         force_base_prompt=force_base_prompt,
         dataset=dataset,
         base_url=base_url,
+        verify_certificate=verify_certificate,
         tp=tp,
         instruction_prefix=instruction_prefix,
         response_prefix=response_prefix,

--- a/evalplus/provider/__init__.py
+++ b/evalplus/provider/__init__.py
@@ -20,6 +20,7 @@ def make_model(
     enable_chunked_prefill=False,
     # openai only
     base_url=None,
+    verify_certificate=True,
     # hf only
     attn_implementation="eager",
     device_map=None,
@@ -71,6 +72,7 @@ def make_model(
             batch_size=batch_size,
             temperature=temperature,
             base_url=base_url,
+            verify_certificate=verify_certificate,
             instruction_prefix=instruction_prefix,
             response_prefix=response_prefix,
         )

--- a/evalplus/provider/openai.py
+++ b/evalplus/provider/openai.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 
+import httpx
 import openai
 
 from evalplus.gen.util import openai_request
@@ -9,9 +10,10 @@ from evalplus.provider.utility import concurrent_call
 
 
 class OpenAIChatDecoder(DecoderBase):
-    def __init__(self, name: str, base_url=None, **kwargs) -> None:
+    def __init__(self, name: str, base_url=None, verify_certificate=True, **kwargs) -> None:
         super().__init__(name, **kwargs)
         self.base_url = base_url
+        self.verify_certificate = verify_certificate
 
     def codegen(
         self, prompt: str, do_sample: bool = True, num_samples: int = 200
@@ -29,7 +31,11 @@ class OpenAIChatDecoder(DecoderBase):
 
     def _codegen_api_batch(self, prompt: str, batch_size: int) -> List[str]:
         client = openai.OpenAI(
-            api_key=os.getenv("OPENAI_API_KEY", "none"), base_url=self.base_url
+            api_key=os.getenv("OPENAI_API_KEY", "none"),
+            base_url=self.base_url,
+            http_client= httpx.Client(
+                verify=self.verify_certificate
+            )
         )
 
         ret = openai_request.make_auto_request(


### PR DESCRIPTION
This PR adds a verify_certificate parameter (defaulting to True) to support custom model URLs with self-signed or invalid SSL certificates. Currently, strict certificate validation blocks such connections, preventing evaluations from running. By setting verify_certificate=False, users can bypass SSL verification when needed.