### PR TITLE
fix: fix issue with HF tokenizer

### DIFF
--- a/evalplus/provider/hf.py
+++ b/evalplus/provider/hf.py
@@ -40,9 +40,7 @@ class HuggingFaceDecoder(DecoderBase):
 
         # gguf format embeds tokenizer and is not compatible with hf tokenizer `use_fast` param
         tokenizer_kwargs = {}
-        if gguf_file is None:
-            tokenizer_kwargs["use_fast"] = False
-        else:
+        if gguf_file is not None:
             tokenizer_kwargs["gguf_file"] = gguf_file
         self.tokenizer = AutoTokenizer.from_pretrained(name, **tokenizer_kwargs)
         if self.is_direct_completion():  # no chat template

--- a/evalplus/provider/vllm.py
+++ b/evalplus/provider/vllm.py
@@ -35,9 +35,7 @@ class VllmDecoder(DecoderBase):
         self.force_base_prompt = force_base_prompt
         # gguf format embeds tokenizer and is not compatible with hf tokenizer `use_fast` param
         tokenizer_kwargs = {}
-        if gguf_file is None:
-            tokenizer_kwargs["use_fast"] = False
-        else:
+        if gguf_file is not None:
             tokenizer_kwargs["gguf_file"] = gguf_file
         self.tokenizer = AutoTokenizer.from_pretrained(self.name, **tokenizer_kwargs)
         if self.is_direct_completion():


### PR DESCRIPTION
For some models, when loading the HF tokenizer with `use_fast=False`, `AutoTokenizer.from_pretrained(xxx, use_fast=False)` returns a boolean

```
>>> tok = AutoTokenizer.from_pretrained("unsloth/Llama-4-Scout-17B-16E-Instruct-unsloth-bnb-4bit", use_fast=False)
>>> tok
False
>>> 
```

Thus breaking the evalplus code later on. 
This PR fixes this issue by avoid passing the parameter `use_fast`. The code will still remain compatible with GGUF models since the default `use_fast` is used anyway if `gguf_file` is passed.

To repro the issue:

```bash
evalplus.evaluate --model meta-llama/Llama-4-Scout-17B-16E-Instruct --trust_remote_code True --dtype bfloat16 --backend vllm --tp 8 --attn_implementation sdpa --greedy  --bs 2 --dataset humaneval --root /tmp/tmpr2p3dtyn
```