### PR TITLE
fix: detect return-value deception via dunder override (same exploit class as HumanEval)

### DIFF
--- a/evalplus/eval/__init__.py
+++ b/evalplus/eval/__init__.py
@@ -153,7 +153,19 @@ def unsafe_execute(
                         with swallow_io():
                             out = fn(*inp)
 
+                    # Return-value deception defense: verify the output type
+                    # matches the expected type. A model can return a custom
+                    # object whose __eq__ always returns True to bypass all
+                    # comparisons without solving the problem. Use type()
+                    # identity to reject dunder-overriding subclasses.
                     exp = expected[i]
+                    if exp is not None and type(out) is not type(exp):
+                        # Allow int/float cross-comparison (common in math tasks)
+                        if not (isinstance(out, (int, float)) and isinstance(exp, (int, float))):
+                            stat.append(0)  # treat as mismatch
+                            details.append({"output": str(out), "expected": str(exp)})
+                            continue
+
                     exact_match = out == exp
 
                     # ================================================ #


### PR DESCRIPTION
## Summary

A model can return a custom object whose `__eq__` always returns `True`, causing all comparisons (`out == exp`) and special oracles in EvalPlus to pass **without solving the problem**. A model can score 100% on HumanEval+ and MBPP+ by returning `_AlwaysEqual()` from every function.

This is the **same exploit class** found in HumanEval (openai/human-eval#67), now confirmed against EvalPlus's hardened test suite — including the special oracles.

## The exploit

```python
class _AlwaysEqual:
    def __eq__(self, other): return True
    def __sub__(self, other): return _AlwaysEqual()
    def __abs__(self): return 0.0

def solve(args):
    return _AlwaysEqual()
```

EvalPlus then does (`eval/__init__.py:155-157`):
```python
out = fn(*inp)           # Returns _AlwaysEqual()
exact_match = out == exp # _AlwaysEqual().__eq__(exp) → True
```

Every comparison passes. The special oracles (`abs(out - x) <= atol`) also pass because `__sub__` and `__abs__` are overridden.

## Verified

| Comparison | Result |
|---|---|
| `out == False` | `True` (should be wrong) |
| `out == [1,2,3]` | `True` |
| `out == 42` | `True` |
| `abs(out - 5) <= 0.1` | `True` (oracle bypassed) |

## Fix

Add a `type()` identity check before the comparison: if `type(out) is not type(exp)`, treat as a mismatch (skip the `==` comparison). Allows `int`/`float` cross-comparison for math tasks.

### Verified

- `_AlwaysEqual()` vs `bool` → **BLOCKED** (type mismatch) ✅
- `True` vs `bool` → allowed (correct) ✅
- `42` vs `float` → allowed (numeric cross-type) ✅

## Scope

This affects HumanEval+, MBPP+, and any EvalPlus-evaluated benchmark. The fix is in the core evaluation loop, protecting all datasets automatically.

## Related

- openai/human-eval#67 — same exploit class, same fix pattern in the original HumanEval.

## Checklist

- [x] Code compiles (`py_compile` passes)
- [x] Fix verified: exploit blocked, correct implementations unaffected
- [x] Numeric cross-type comparison preserved for math tasks