### PR TITLE
feat: Wilson CI + paired McNemar reporting for eval_results

### DIFF
--- a/evalplus/report.py
+++ b/evalplus/report.py
@@ -1,0 +1,88 @@
+"""Summarization of ``eval_results.json`` for honest leaderboard reporting.
+
+Separates two metrics that are often conflated:
+
+* ``pass@1`` — the standard EvalPlus estimator (``estimate_pass_at_k`` with
+  ``k=1``), averaged over tasks exactly as ``evalplus.evaluate`` reports it;
+* ``resolved`` — the per-task binary outcome "at least one sample passed",
+  which is the convention used by SWE-bench-style paired comparisons and the
+  metric on which the Wilson confidence interval is computed.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from evalplus.eval import PASS, estimate_pass_at_k
+from evalplus.uncertainty import paired_mcnemar, wilson_ci
+
+SampleOutcome = Tuple[bool, bool]  # (base_ok, plus_ok)
+
+
+def load_per_task(results: dict) -> Dict[str, List[SampleOutcome]]:
+    """Return {task_id: [(base_ok, plus_ok), ...]} from an evalplus result dict."""
+    per_task = {}
+    for task_id, samples in results.get("eval", {}).items():
+        per_task[task_id] = [
+            (
+                s.get("base_status") == PASS,
+                s.get("base_status") == PASS and s.get("plus_status") == PASS,
+            )
+            for s in samples
+        ]
+    return per_task
+
+
+def summarize(per_task: Dict[str, List[SampleOutcome]]) -> dict:
+    """Aggregate pass@1 (upstream semantics) and per-task resolved rates."""
+    n_tasks = len(per_task)
+    if n_tasks == 0:
+        raise ValueError("no tasks in results")
+    total = np.array([len(s) for s in per_task.values()])
+    base_c = np.array([sum(1 for ok, _ in s if ok) for s in per_task.values()])
+    plus_c = np.array([sum(1 for _, ok in s if ok) for s in per_task.values()])
+    resolved_base = np.array([any(ok for ok, _ in s) for s in per_task.values()])
+    resolved_plus = np.array([any(ok for _, ok in s) for s in per_task.values()])
+
+    pass1_base = float(estimate_pass_at_k(total, base_c, 1).mean())
+    pass1_plus = float(estimate_pass_at_k(total, plus_c, 1).mean())
+    r_base = int(resolved_base.sum())
+    r_plus = int(resolved_plus.sum())
+    lo_b, hi_b = wilson_ci(r_base, n_tasks)
+    lo_p, hi_p = wilson_ci(r_plus, n_tasks)
+
+    return {
+        "tasks": n_tasks,
+        "samples_per_task_min": int(total.min()),
+        "samples_per_task_max": int(total.max()),
+        "pass1_base": pass1_base,
+        "pass1_plus": pass1_plus,
+        "resolved_base": r_base / n_tasks,
+        "resolved_base_ci": (lo_b, hi_b),
+        "resolved_plus": r_plus / n_tasks,
+        "resolved_plus_ci": (lo_p, hi_p),
+    }
+
+
+def compare(
+    per_task_a: Dict[str, List[SampleOutcome]],
+    per_task_b: Dict[str, List[SampleOutcome]],
+) -> dict:
+    """Exact paired McNemar on per-task resolved (base) outcomes."""
+    resolved_a = {t: any(ok for ok, _ in s) for t, s in per_task_a.items()}
+    resolved_b = {t: any(ok for ok, _ in s) for t, s in per_task_b.items()}
+    shared = [t for t in resolved_a if t in resolved_b]
+    if not shared:
+        raise ValueError("no shared tasks between the two result files")
+    both = sum(1 for t in shared if resolved_a[t] and resolved_b[t])
+    a_only = sum(1 for t in shared if resolved_a[t] and not resolved_b[t])
+    b_only = sum(1 for t in shared if resolved_b[t] and not resolved_a[t])
+    return {
+        "shared": len(shared),
+        "both": both,
+        "a_only": a_only,
+        "b_only": b_only,
+        "p": paired_mcnemar(a_only, b_only),
+    }

--- a/evalplus/report.py
+++ b/evalplus/report.py
@@ -70,12 +70,25 @@ def compare(
     per_task_a: Dict[str, List[SampleOutcome]],
     per_task_b: Dict[str, List[SampleOutcome]],
 ) -> dict:
-    """Exact paired McNemar on per-task resolved (base) outcomes."""
+    """Exact paired McNemar on per-task resolved (base) outcomes.
+
+    Paired comparison is only meaningful when each shared task was measured
+    under the same conditions, so this also reports shared tasks whose sample
+    counts differ between the two result files (e.g. A ran 1 trial per task,
+    B ran 10: ``resolved`` would then give B ten chances to pass). Callers
+    should treat ``sample_count_mismatches`` as a hard guardrail unless they
+    explicitly accept unmatched conditions.
+    """
     resolved_a = {t: any(ok for ok, _ in s) for t, s in per_task_a.items()}
     resolved_b = {t: any(ok for ok, _ in s) for t, s in per_task_b.items()}
+    counts_a = {t: len(s) for t, s in per_task_a.items()}
+    counts_b = {t: len(s) for t, s in per_task_b.items()}
     shared = [t for t in resolved_a if t in resolved_b]
     if not shared:
         raise ValueError("no shared tasks between the two result files")
+    mismatched = sorted(
+        t for t in shared if counts_a[t] != counts_b[t]
+    )
     both = sum(1 for t in shared if resolved_a[t] and resolved_b[t])
     a_only = sum(1 for t in shared if resolved_a[t] and not resolved_b[t])
     b_only = sum(1 for t in shared if resolved_b[t] and not resolved_a[t])
@@ -85,4 +98,5 @@ def compare(
         "a_only": a_only,
         "b_only": b_only,
         "p": paired_mcnemar(a_only, b_only),
+        "sample_count_mismatches": mismatched,
     }

--- a/evalplus/uncertainty.py
+++ b/evalplus/uncertainty.py
@@ -1,0 +1,43 @@
+"""Statistical helpers for comparing fixed-item evaluation results.
+
+Implements the Wilson score interval for pass rates and an exact paired
+McNemar test for comparing two models on the same fixed item set. Only the
+standard library is required.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def wilson_ci(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Return the (lower, upper) Wilson score interval for a proportion.
+
+    The Wilson interval is well behaved near 0 and 1, unlike the normal
+    approximation, which makes it suitable for fixed-item leaderboards where
+    pass rates are often extreme (e.g. 0.95 or 0.05).
+    """
+    if n <= 0:
+        return (0.0, 0.0)
+    p = successes / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    margin = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def paired_mcnemar(a_only: int, b_only: int, two_sided: bool = True) -> float:
+    """Exact binomial p-value for the paired McNemar test.
+
+    ``a_only`` is the number of items solved by A but not B; ``b_only`` the
+    reverse. Under the null hypothesis the discordant items split 50/50, so
+    the test reduces to a binomial test on the smaller discordant count.
+    """
+    n = a_only + b_only
+    if n == 0:
+        return 1.0
+    k = min(a_only, b_only)
+    tail = 0.0
+    for i in range(k + 1):
+        tail += math.comb(n, i) / (2**n)
+    return min(1.0, 2 * tail) if two_sided else tail

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -62,6 +62,28 @@ def test_pass1_matches_upstream_estimator():
     assert abs(s["pass1_base"] - expected) < 1e-12
 
 
+def test_compare_detects_unmatched_sample_counts():
+    a = make_results(
+        {"t1": [(PASS, PASS)], "t2": [(PASS, PASS)], "t3": [(FAIL, FAIL)]}
+    )
+    b = make_results(
+        {
+            "t1": [(PASS, PASS), (PASS, PASS)],
+            "t2": [(PASS, PASS)],
+            "t3": [(FAIL, FAIL)],
+        }
+    )
+    c = compare(load_per_task(a), load_per_task(b))
+    assert c["sample_count_mismatches"] == ["t1"]
+    assert c["shared"] == 3
+
+    d = make_results(
+        {"t1": [(PASS, PASS)], "t2": [(PASS, PASS)], "t3": [(FAIL, FAIL)]}
+    )
+    e = compare(load_per_task(a), load_per_task(d))
+    assert e["sample_count_mismatches"] == []
+
+
 def test_compare_counts_and_p():
     a = make_results(
         {"t1": [(PASS, PASS)], "t2": [(PASS, PASS)], "t3": [(FAIL, FAIL)]}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+from evalplus.eval import estimate_pass_at_k
+from evalplus.report import compare, load_per_task, summarize
+
+
+PASS = "pass"
+FAIL = "fail"
+
+
+def make_results(per_task):
+    """Build an evalplus-style results dict from {task_id: [statuses]}."""
+    return {
+        "eval": {
+            task_id: [
+                {"base_status": b, "plus_status": p} for b, p in statuses
+            ]
+            for task_id, statuses in per_task.items()
+        }
+    }
+
+
+def test_single_sample_pass1_equals_resolved():
+    results = make_results(
+        {"t1": [(PASS, PASS)], "t2": [(FAIL, FAIL)], "t3": [(PASS, FAIL)]}
+    )
+    s = summarize(load_per_task(results))
+    assert s["pass1_base"] == 2 / 3
+    assert s["resolved_base"] == 2 / 3
+    assert s["pass1_plus"] == 1 / 3
+    assert s["resolved_plus"] == 1 / 3
+
+
+def test_multi_sample_semantics_are_distinct():
+    # t1: 1/2 samples pass -> pass@1 = 0.5, but resolved = 1.0
+    results = make_results(
+        {
+            "t1": [(PASS, PASS), (FAIL, FAIL)],
+            "t2": [(FAIL, FAIL), (FAIL, FAIL)],
+        }
+    )
+    per_task = load_per_task(results)
+    s = summarize(per_task)
+    assert s["pass1_base"] == 0.25
+    assert s["resolved_base"] == 0.5
+    assert s["samples_per_task_min"] == 2
+    assert s["samples_per_task_max"] == 2
+
+
+def test_pass1_matches_upstream_estimator():
+    results = make_results(
+        {
+            "t1": [(PASS, PASS), (FAIL, FAIL), (FAIL, FAIL)],
+            "t2": [(PASS, PASS), (PASS, FAIL)],
+        }
+    )
+    per_task = load_per_task(results)
+    total = np.array([3, 2])
+    base_c = np.array([1, 2])
+    expected = float(estimate_pass_at_k(total, base_c, 1).mean())
+    s = summarize(per_task)
+    assert abs(s["pass1_base"] - expected) < 1e-12
+
+
+def test_compare_counts_and_p():
+    a = make_results(
+        {"t1": [(PASS, PASS)], "t2": [(PASS, PASS)], "t3": [(FAIL, FAIL)]}
+    )
+    b = make_results(
+        {"t1": [(PASS, PASS)], "t2": [(FAIL, FAIL)], "t3": [(PASS, PASS)]}
+    )
+    c = compare(load_per_task(a), load_per_task(b))
+    assert c["shared"] == 3
+    assert c["both"] == 1
+    assert c["a_only"] == 1
+    assert c["b_only"] == 1
+    assert abs(c["p"] - 1.0) < 1e-12

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,33 @@
+import math
+
+from evalplus.uncertainty import paired_mcnemar, wilson_ci
+
+
+def test_wilson_ci_center():
+    lo, hi = wilson_ci(50, 100)
+    assert abs((lo + hi) / 2 - 0.5) < 1e-9
+    assert lo < 0.5 < hi
+
+
+def test_wilson_ci_extreme():
+    lo, hi = wilson_ci(0, 10)
+    assert lo == 0.0
+    lo, hi = wilson_ci(10, 10)
+    assert hi == 1.0
+
+
+def test_wilson_ci_reference():
+    # Wilson 95% interval for 50/100 is (0.402, 0.598) to 3 decimals.
+    lo, hi = wilson_ci(50, 100)
+    assert abs(lo - 0.4038) < 0.001
+    assert abs(hi - 0.5962) < 0.001
+
+
+def test_mcnemar_classic():
+    # The textbook (1, 9) discordant pair yields a two-sided p of ~0.0215.
+    p = paired_mcnemar(1, 9)
+    assert abs(p - 0.02148) < 0.0001
+
+
+def test_mcnemar_no_discordance():
+    assert paired_mcnemar(0, 0) == 1.0

--- a/tools/ci_report.py
+++ b/tools/ci_report.py
@@ -11,6 +11,12 @@ and prints:
 With ``--compare``, runs an exact paired McNemar test between two result
 files on their shared task set, using the per-task resolved (base) outcomes.
 
+A paired comparison is only valid under matched measurement conditions, so
+``--compare`` aborts by default when any shared task has a different sample
+count in the two files (e.g. 1 trial per task vs. 10 trials per task would
+give the 10-trial run ten chances to resolve a task as passed). Pass
+``--allow-unmatched-samples`` to compare anyway.
+
 Examples::
 
     python tools/ci_report.py --results path/to/eval_results.json
@@ -27,6 +33,11 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--results", required=True, help="eval_results.json")
     parser.add_argument("--compare", help="second eval_results.json for McNemar")
+    parser.add_argument(
+        "--allow-unmatched-samples",
+        action="store_true",
+        help="compare even if shared tasks have different per-task sample counts",
+    )
     args = parser.parse_args()
 
     with open(args.results, encoding="utf-8") as f:
@@ -50,6 +61,15 @@ def main():
             other = json.load(f)
         other_per_task = load_per_task(other)
         c = compare(per_task, other_per_task)
+        if c["sample_count_mismatches"] and not args.allow_unmatched_samples:
+            shown = ", ".join(c["sample_count_mismatches"][:5])
+            raise SystemExit(
+                f"error: {len(c['sample_count_mismatches'])} shared task(s) "
+                f"have different per-task sample counts ({shown}"
+                f"{', ...' if len(c['sample_count_mismatches']) > 5 else ''}); "
+                "the measurement conditions are not paired. Re-run with "
+                "--allow-unmatched-samples to compare anyway."
+            )
         print(f"paired comparison on {c['shared']} shared tasks "
               f"(resolved base): both {c['both']} | A-only {c['a_only']} | "
               f"B-only {c['b_only']} | McNemar p {c['p']:.4f}")

--- a/tools/ci_report.py
+++ b/tools/ci_report.py
@@ -1,0 +1,59 @@
+"""Report pass@1 and per-task resolved rates with 95% Wilson CIs.
+
+Reads an EvalPlus ``eval_results.json`` (as written by ``evalplus.evaluate``)
+and prints:
+
+* ``pass@1`` (base and plus) — the standard EvalPlus estimator, averaged over
+  tasks exactly as upstream reports it;
+* ``resolved`` (base and plus) — the per-task binary "at least one sample
+  passed" rate, with a 95% Wilson score interval.
+
+With ``--compare``, runs an exact paired McNemar test between two result
+files on their shared task set, using the per-task resolved (base) outcomes.
+
+Examples::
+
+    python tools/ci_report.py --results path/to/eval_results.json
+    python tools/ci_report.py --results model_a.json --compare model_b.json
+"""
+
+import argparse
+import json
+
+from evalplus.report import compare, load_per_task, summarize
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", required=True, help="eval_results.json")
+    parser.add_argument("--compare", help="second eval_results.json for McNemar")
+    args = parser.parse_args()
+
+    with open(args.results, encoding="utf-8") as f:
+        results = json.load(f)
+    per_task = load_per_task(results)
+    s = summarize(per_task)
+
+    print(f"tasks: {s['tasks']}  (samples/task: "
+          f"{s['samples_per_task_min']}-{s['samples_per_task_max']})")
+    lo, hi = s["resolved_base_ci"]
+    print(f"pass@1 (base): {s['pass1_base']:.4f}")
+    print(f"resolved (base): {s['resolved_base']:.4f}  "
+          f"95% CI [{lo:.4f}, {hi:.4f}]")
+    lo, hi = s["resolved_plus_ci"]
+    print(f"pass@1 (plus): {s['pass1_plus']:.4f}")
+    print(f"resolved (plus): {s['resolved_plus']:.4f}  "
+          f"95% CI [{lo:.4f}, {hi:.4f}]")
+
+    if args.compare:
+        with open(args.compare, encoding="utf-8") as f:
+            other = json.load(f)
+        other_per_task = load_per_task(other)
+        c = compare(per_task, other_per_task)
+        print(f"paired comparison on {c['shared']} shared tasks "
+              f"(resolved base): both {c['both']} | A-only {c['a_only']} | "
+              f"B-only {c['b_only']} | McNemar p {c['p']:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixed-item leaderboards rank models strictly, but on the same item set the honest comparison is paired. This PR adds the minimal tooling to make that explicit:

- `evalplus/uncertainty.py` — stdlib-only `wilson_ci` and exact paired `paired_mcnemar`
- `evalplus/report.py` — separates two metrics that upstream `evalplus.evaluate` already distinguishes but does not expose per-task:
  - **pass@1 (base/plus)**: the standard unbiased `estimate_pass_at_k` with k=1, averaged over tasks exactly as upstream reports it
  - **resolved (base/plus)**: the per-task binary "at least one sample passed" rate — the convention used by SWE-bench-style paired comparisons — with a 95% Wilson score interval
- `tools/ci_report.py` — prints both metrics for a single `eval_results.json`; with `--compare`, runs an exact paired McNemar test between two result files on their shared task set using the per-task resolved (base) outcomes
- `tests/test_uncertainty.py` + `tests/test_report.py` — unit tests, including the multi-sample case that makes the pass@1-vs-resolved distinction explicit

## Why two metrics?

`eval_results.json` can contain multiple samples per task (upstream `evaluate.py` aggregates them with `estimate_pass_at_k`). "pass@1" is the unbiased estimator over all samples of a task; "resolved" is whether at least one sample passed. They are different numbers (e.g. 1 of 2 samples passing = pass@1 0.5 but resolved 1.0), and conflating them silently changes meaning. The CLI therefore prints both and labels them exactly.

## Paired-comparison guardrail

`resolved` ("at least one sample passed") makes the per-task sample count part of the measurement: comparing a 1-trial run against a 10-trial run on the same items is not paired — the 10-trial run gets ten chances to resolve each task. `compare()` therefore reports shared tasks whose sample counts differ, and `--compare` aborts on any mismatch unless `--allow-unmatched-samples` is passed explicitly.

## Motivation

Related discussion in the benchmark community (e.g. SWE-bench#621): on fixed item sets, rank gaps within the statistical noise band are not meaningful separations. Wilson intervals behave well for extreme pass rates, and the paired McNemar test answers "is the #1-vs-#k gap real" directly.

## Testing

- `python -m pytest tests/test_uncertainty.py tests/test_report.py` — 10 passed
- Manual smoke test of the CLI against two small result files
